### PR TITLE
Minor fix CHANGELOG formatting mistakes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /spec/reports/
 /tmp/
 *.swp
+*.gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,23 @@ this project versions are for now mere release numbers. They don't have any part
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## 0.1.2 - 2017-08-04
+## [0.1.2] - 2017-08-04
 
 ### Fixed
 
 - Removing unnecessary files from gemspec
 
-## 0.1.1 - 2017-08-03
+## [0.1.1] - 2017-08-03
 
 ### Fixed
 
 - Including files in gemspec
 
-## 0.1.0 - 2017-08-03
+## 0.1.0 - 2017-08-03 [YANKED]
 
 ### Added
 
 - Initial implementation of the `Megaphone::Client.publish!` method
 
+  [0.1.2]: https://github.com/redbubble/megaphone-client-ruby/compare/v0.1.1...v0.1.2
+  [0.1.1]: https://github.com/redbubble/megaphone-client-ruby/compare/v0.1.0...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,15 @@ This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ## 0.1.2 - 2017-08-04
 
-### Fix
+### Fixed
 
 - Removing unnecessary files from gemspec
 
 ## 0.1.1 - 2017-08-03
 
-### Fix
+### Fixed
 
-- Including files in .gemspec
+- Including files in gemspec
 
 ## 0.1.0 - 2017-08-03
 


### PR DESCRIPTION
This PR is a follow up on #2 

**When I** use the keepachangelog.com format 
**I want** my change log to be actually formatted according to the docs 
**So that** I can eventually be parsed automatically by external tools 

See https://trello.com/c/7rF07RZF/35-first-iteration-of-megaphoneclient-ruby