### PR TITLE
Add a file logger to be used when no fluentd port is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ gem 'megaphone-client', '~> 0.1.0'
 
 Usage
 -----
+The client will append events to local files unless a `MEGAPHONE_FLUENT_HOST` and `MEGAPHONE_FLUENT_PORT` environment variables are set.
 
 To publish an event on Megaphone
 ```ruby
@@ -57,4 +58,3 @@ License
 
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
-

--- a/lib/megaphone/client.rb
+++ b/lib/megaphone/client.rb
@@ -1,4 +1,4 @@
-require 'megaphone/client/fluent_logger'
+require 'megaphone/client/logger'
 require 'megaphone/client/errors'
 require 'megaphone/client/event'
 require 'megaphone/client/version'
@@ -8,7 +8,7 @@ module Megaphone
     attr_reader :logger, :origin
     private :logger, :origin
 
-    def initialize(config, logger = Megaphone::Client::FluentLogger.new)
+    def initialize(config, logger = Megaphone::Client::Logger.create)
       @logger = logger
       @origin = config.fetch(:origin)
     end

--- a/lib/megaphone/client/file_logger.rb
+++ b/lib/megaphone/client/file_logger.rb
@@ -1,0 +1,17 @@
+require 'json'
+
+module Megaphone
+  class Client
+    class FileLogger
+      def post(topic, event)
+        File.open("#{topic}.stream", 'a') do |f|
+          f.puts event.to_json
+        end
+        true
+      end
+
+      def last_error
+      end
+    end
+  end
+end

--- a/lib/megaphone/client/fluent_logger.rb
+++ b/lib/megaphone/client/fluent_logger.rb
@@ -8,9 +8,7 @@ module Megaphone
 
       def_delegators :@logger, :post, :last_error
 
-      def initialize
-        host = 'localhost'
-        port = 24224
+      def initialize(host, port)
         @logger = Fluent::Logger::FluentLogger.new('megaphone',
                                                    host: host,
                                                    port: port)

--- a/lib/megaphone/client/logger.rb
+++ b/lib/megaphone/client/logger.rb
@@ -1,0 +1,18 @@
+require 'megaphone/client/file_logger'
+require 'megaphone/client/fluent_logger'
+
+module Megaphone
+  class Client
+    class Logger
+      def self.create
+        fluentd_host = ENV["MEGAPHONE_FLUENT_HOST"]
+        fluentd_port = ENV["MEGAPHONE_FLUENT_PORT"]
+        if !fluentd_port.nil? && !fluentd_port.empty? &&
+           !fluentd_host.nil? && !fluentd_host.empty?
+          return Megaphone::Client::FluentLogger.new(fluentd_host, fluentd_port)
+        end
+        Megaphone::Client::FileLogger.new
+      end
+    end
+  end
+end

--- a/spec/megaphone/client/logger_spec.rb
+++ b/spec/megaphone/client/logger_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Megaphone::Client::Logger do
+  describe '#create' do
+    subject { Megaphone::Client::Logger.create }
+
+    after do
+      ENV.delete('MEGAPHONE_FLUENT_HOST')
+      ENV.delete('MEGAPHONE_FLUENT_PORT')
+    end
+
+    context 'when megaphone fluent env variables are present' do
+      it 'creates a fluent logger' do
+        ENV['MEGAPHONE_FLUENT_HOST'] = 'localhost'
+        ENV['MEGAPHONE_FLUENT_PORT'] = '24224'
+        expect(subject).to be_an_instance_of(Megaphone::Client::FluentLogger)
+      end
+    end
+
+    context 'when megaphone fluent host env variable is not present' do
+      it 'creates a file logger' do
+        ENV['MEGAPHONE_FLUENT_PORT'] = '24224'
+        expect(subject).to be_an_instance_of(Megaphone::Client::FileLogger)
+      end
+    end
+
+    context 'when megaphone fluent port env variable is not present' do
+      it 'creates a file logger' do
+        ENV['MEGAPHONE_FLUENT_HOST'] = 'localhost'
+        expect(subject).to be_an_instance_of(Megaphone::Client::FileLogger)
+      end
+    end
+
+    context 'when megaphone fluent env variables are not present' do
+      it 'creates a file logger' do
+        expect(subject).to be_an_instance_of(Megaphone::Client::FileLogger)
+      end
+    end
+  end
+end

--- a/spec/megaphone/client_spec.rb
+++ b/spec/megaphone/client_spec.rb
@@ -8,44 +8,63 @@ describe Megaphone::Client do
   describe '#publish!' do
     let(:config) { { origin: 'some-service' } }
     let(:client) do
-      described_class.new(config, fluentd_logger)
+      described_class.new(config, logger)
     end
-
-    let(:fluentd_logger) { instance_double(Megaphone::Client::FluentLogger, post: true) }
 
     let(:topic) { :page_changes }
     let(:subtopic) { :product_pages }
     let(:payload) { { url: 'http://rb.com/' } }
 
-    it 'sends the event to fluentd' do
-      expect(fluentd_logger).to receive(:post).with(topic, {
-        topic: topic,
-        subtopic: subtopic,
-        origin: 'some-service',
-        payload: payload
-      })
-      client.publish!(topic, subtopic, payload)
-    end
+    context 'when fluentd logger is used' do
+      let(:logger) { instance_double(Megaphone::Client::FluentLogger, post: true) }
 
-    context 'when sending event from My Awesome Service' do
-
-      let(:config) { { origin: 'my-awesome-service' } }
-
-      it 'sends the event to fluentd with the origin as my aweseome service' do
-        expect(fluentd_logger).to receive(:post).with(topic, hash_including(origin: 'my-awesome-service'))
+      it 'sends the event to fluentd' do
+        expect(logger).to receive(:post).with(topic, {
+          topic: topic,
+          subtopic: subtopic,
+          origin: 'some-service',
+          payload: payload
+        })
         client.publish!(topic, subtopic, payload)
       end
-    end
 
-    context 'when Megaphone (fluentd) is unavailable' do
+      context 'when sending event from My Awesome Service' do
 
-      before(:each) do
-        allow(fluentd_logger).to receive(:post).and_return(false)
-        allow(fluentd_logger).to receive(:last_error).and_return(Errno::ECONNREFUSED.new)
+        let(:config) { { origin: 'my-awesome-service' } }
+
+        it 'sends the event to fluentd with the origin as my awesome service' do
+          expect(logger).to receive(:post).with(topic, hash_including(origin: 'my-awesome-service'))
+          client.publish!(topic, subtopic, payload)
+        end
       end
 
-      it 'raises an error' do
-        expect { client.publish!(topic, subtopic, payload) }.to raise_error(Megaphone::Client::MegaphoneUnavailableError, /The following event was not published/)
+      context 'when Megaphone (fluentd) is unavailable' do
+
+        before(:each) do
+          allow(logger).to receive(:post).and_return(false)
+          allow(logger).to receive(:last_error).and_return(Errno::ECONNREFUSED.new)
+        end
+
+        it 'raises an error' do
+          expect { client.publish!(topic, subtopic, payload) }.to raise_error(Megaphone::Client::MegaphoneUnavailableError, /The following event was not published/)
+        end
+      end
+    end
+
+    context 'when file logger is used' do
+      let(:logger) { Megaphone::Client::FileLogger.new }
+      let(:expected_filename) { "page_changes.stream" }
+      let(:expected_file_permission) { "a" }
+      let(:expected_file_content) do
+        "{\"topic\":\"page_changes\",\"subtopic\":\"product_pages\",\"origin\":\"some-service\",\"payload\":{\"url\":\"http://rb.com/\"}}"
+      end
+
+      it 'sends the event to a file' do
+        file = double('file')
+        expect(File).to receive(:open).with(expected_filename, expected_file_permission).and_yield(file)
+        expect(file).to receive(:puts).with(expected_file_content)
+
+        client.publish!(topic, subtopic, payload)
       end
     end
   end


### PR DESCRIPTION
**When I** use the megaphone ruby client
**And** I am not running fluentd on my machine
**I want** the megaphony ruby client not to fail
**And** any events I send to be saved in a local file
**So that** I can look at the generated events if I need to

https://trello.com/c/OeXoqfxa/65-make-sure-the-ruby-client-writes-the-events-to-a-file-in-the-dev-environment