### PR TITLE
Add host and port into client configuration parameters :pear: @Tavio

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ gem 'megaphone-client', '~> 0.2.0'
 
 Usage
 -----
-The client will append events to local files unless a `MEGAPHONE_FLUENT_HOST` and `MEGAPHONE_FLUENT_PORT` environment variables are set.
+The client will append events to local files unless the fluentd host and port values are passed as arguments to the client's constructor or the `MEGAPHONE_FLUENT_HOST` and `MEGAPHONE_FLUENT_PORT` environment variables are set.
 
 To publish an event on Megaphone
 ```ruby
-event_bus = Megaphone::Client.new({ origin: 'my-awesome-service' })
+event_bus = Megaphone::Client.new({ origin: 'my-awesome-service', host: 'localhost', port: '24224' })
 
 topic = :page_changes
 subtopic = :product_pages

--- a/lib/megaphone/client.rb
+++ b/lib/megaphone/client.rb
@@ -8,9 +8,10 @@ module Megaphone
     attr_reader :logger, :origin
     private :logger, :origin
 
-    def initialize(config, logger = Megaphone::Client::Logger.create)
-      @logger = logger
+    def initialize(config)
       @origin = config.fetch(:origin)
+      @logger = Megaphone::Client::Logger.create(config[:host],
+                                                 config[:port])
     end
 
     def publish!(topic, subtopic, schema, partition_key, payload)

--- a/lib/megaphone/client/logger.rb
+++ b/lib/megaphone/client/logger.rb
@@ -4,9 +4,9 @@ require 'megaphone/client/fluent_logger'
 module Megaphone
   class Client
     class Logger
-      def self.create
-        fluentd_host = ENV["MEGAPHONE_FLUENT_HOST"]
-        fluentd_port = ENV["MEGAPHONE_FLUENT_PORT"]
+      def self.create(host = nil, port = nil)
+        fluentd_host = host || ENV["MEGAPHONE_FLUENT_HOST"]
+        fluentd_port = port || ENV["MEGAPHONE_FLUENT_PORT"]
         if !fluentd_port.nil? && !fluentd_port.empty? &&
            !fluentd_host.nil? && !fluentd_host.empty?
           return Megaphone::Client::FluentLogger.new(fluentd_host, fluentd_port)

--- a/spec/megaphone/client/logger_spec.rb
+++ b/spec/megaphone/client/logger_spec.rb
@@ -2,13 +2,35 @@ require 'spec_helper'
 
 describe Megaphone::Client::Logger do
   describe '#create' do
-    subject { Megaphone::Client::Logger.create }
+    let(:host) { nil }
+    let(:port) { nil }
+
+    subject { Megaphone::Client::Logger.create(host, port) }
 
     after do
       ENV.delete('MEGAPHONE_FLUENT_HOST')
       ENV.delete('MEGAPHONE_FLUENT_PORT')
     end
 
+    context 'when host and port are present' do
+
+      let(:host) { 'localhost' }
+      let(:port) { '24224' }
+
+      it 'creates a fluent logger using them' do
+        expect(subject).to be_an_instance_of(Megaphone::Client::FluentLogger)
+
+      end
+
+      context 'when megaphone fluent env variables are present' do
+        it 'creates a fluent logger using host and port (not environment variables)' do
+          ENV['MEGAPHONE_FLUENT_HOST'] = 'another-host'
+          ENV['MEGAPHONE_FLUENT_PORT'] = 'another-port'
+          expect(Megaphone::Client::FluentLogger).to receive(:new).with(host, port)
+          subject
+        end
+      end
+    end
     context 'when megaphone fluent env variables are present' do
       it 'creates a fluent logger' do
         ENV['MEGAPHONE_FLUENT_HOST'] = 'localhost'

--- a/spec/megaphone/client_spec.rb
+++ b/spec/megaphone/client_spec.rb
@@ -8,7 +8,7 @@ describe Megaphone::Client do
   describe '#publish!' do
     let(:config) { { origin: 'some-service' } }
     let(:client) do
-      described_class.new(config, logger)
+      described_class.new(config)
     end
 
     let(:topic) { :page_changes }
@@ -16,6 +16,10 @@ describe Megaphone::Client do
     let(:schema) { 'http://www.github.com/redbuble/megaphone-event-type-registry/topics/cats' }
     let(:payload) { { url: 'http://rb.com/' } }
     let(:partition_key) { 42 }
+
+    before do
+      allow(Megaphone::Client::Logger).to receive(:create).and_return(logger)
+    end
 
     context 'when fluentd logger is used' do
       let(:logger) { instance_double(Megaphone::Client::FluentLogger, post: true) }


### PR DESCRIPTION
Fluentd host and port can now be specified as arguments in the client's constructor as well as env variable to facilitate deployments.