### PR TITLE
Bump 0.3.0 :pear: @Tavio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ this project versions are for now mere release numbers. They don't have any part
 This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
+## [0.3.0] - 2017-08-17
+
+### Changed
+
+- Signature of the `Megaphone::Client` constructor : now takes a host and a port as optional arguments and doesn't take the logger as an argument anymore.
+
 ## [0.2.0] - 2017-08-14
 
 ### Changed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    megaphone-client (0.2.0)
+    megaphone-client (0.3.0)
       fluent-logger (~> 0.7.0)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Add the gem to your `Gemfile`:
 ```ruby
 # Gemfile
 
-gem 'megaphone-client', '~> 0.2.0'
+gem 'megaphone-client', '~> 0.3.0'
 ```
 
 Usage

--- a/lib/megaphone/client/version.rb
+++ b/lib/megaphone/client/version.rb
@@ -1,5 +1,5 @@
 module Megaphone
   class Client
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end


### PR DESCRIPTION
Changes:
- Signature of the `Megaphone::Client` constructor : now takes a host and a port as optional arguments and doesn't take the logger as an argument anymore.