### PR TITLE
Refactor redistribute configuration responsibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,40 @@ gem 'megaphone-client', '~> 0.3.0'
 
 Usage
 -----
-The client will append events to local files unless the fluentd host and port values are passed as arguments to the client's constructor or the `MEGAPHONE_FLUENT_HOST` and `MEGAPHONE_FLUENT_PORT` environment variables are set.
 
-To publish an event on Megaphone
+In order to be as unobstrusive as possible, this client will append events to local files (e.g. `./work-updates.stream`) unless:
+
+- the `MEGAPHONE_FLUENT_HOST` and `MEGAPHONE_FLUENT_PORT` environment variables are set.
+- **or** the Fluentd host and port values are passed as arguments to the client's constructor
+
+That behaviour ensures that unless you want to send events to the Megaphone [streams][stream], you do not need to [start Fluentd][megaphone-fluentd] at all.
+
+  [stream]: https://github.com/redbubble/com/megaphone#stream
+  [megaphone-fluentd]: https://github.com/redbubble/megaphone-fluentd-container
+
+### Publishing events
+
+1. Start Fluentd, the easiest way to do so is using a [`redbubble/megaphone-fluentd`][megaphone-fluentd] container
+
+1. Create your event and publish it:
+
 ```ruby
-event_bus = Megaphone::Client.new({ origin: 'my-awesome-service', host: 'localhost', port: '24224' })
+# Configure a Megaphone client for your awesome service
+client = Megaphone::Client.new({
+  origin: 'my-awesome-service',
+  host: 'localhost',
+  port: '24224'
+})
 
-topic = :page_changes
-subtopic = :product_pages
-schema = 'http://www.github.com/redbuble/megaphone-event-type-registry/topics/cats'
-partition_key = '1357924680'
-payload = { url: 'https://www.redbubble.com/people/wytrab8/works/26039653-toadally-rad?grid_pos=1&p=mens-graphic-t-shirt&rbs=29c497ad-a976-42b8-aa40-0e218903c558&ref=shop_grid&style=mens' }
+# Create an event
+topic = 'work-updates'
+subtopic = 'work-metadata-updated'
+schema = 'https://github.com/redbubble/megaphone-event-type-registry/blob/master/streams/work-updates-schema-1.0.0.json'
+partition_key = '1357924680' # the Work ID in this case
+payload = { url: 'https://www.redbubble.com/people/wytrab8/works/26039653-toadally-rad' }
 
-event_bus.publish!(topic, subtopic, schema, partition_key, payload)
+# Publish your event
+client.publish!(topic, subtopic, schema, partition_key, payload)
 ```
 
 Credits

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Megaphone::Client
 =================
 
 [![Build Status](https://badge.buildkite.com/9f4fdb370f5f295ee6bf3d68937b1be2d7cf9bf65b2c7b4213.svg?branch=master)](https://buildkite.com/redbubble/megaphone-client-ruby)
+[![Gem Version](https://badge.fury.io/rb/megaphone-client.svg)](https://badge.fury.io/rb/megaphone-client)
 
 Send events to Megaphone.
 

--- a/lib/megaphone/client.rb
+++ b/lib/megaphone/client.rb
@@ -10,8 +10,9 @@ module Megaphone
 
     def initialize(config)
       @origin = config.fetch(:origin)
-      @logger = Megaphone::Client::Logger.create(config[:host],
-                                                 config[:port])
+      host = config.fetch(:host, ENV['MEGAPHONE_FLUENT_HOST'])
+      port = config.fetch(:port, ENV['MEGAPHONE_FLUENT_PORT'])
+      @logger = Megaphone::Client::Logger.create(host, port)
     end
 
     def publish!(topic, subtopic, schema, partition_key, payload)

--- a/lib/megaphone/client/logger.rb
+++ b/lib/megaphone/client/logger.rb
@@ -5,13 +5,11 @@ module Megaphone
   class Client
     class Logger
       def self.create(host = nil, port = nil)
-        fluentd_host = host || ENV["MEGAPHONE_FLUENT_HOST"]
-        fluentd_port = port || ENV["MEGAPHONE_FLUENT_PORT"]
-        if !fluentd_port.nil? && !fluentd_port.empty? &&
-           !fluentd_host.nil? && !fluentd_host.empty?
-          return Megaphone::Client::FluentLogger.new(fluentd_host, fluentd_port)
+        if !port.nil? && !port.empty? &&
+           !host.nil? && !host.empty?
+          return FluentLogger.new(host, port)
         end
-        Megaphone::Client::FileLogger.new
+        FileLogger.new
       end
     end
   end

--- a/spec/megaphone/client/logger_spec.rb
+++ b/spec/megaphone/client/logger_spec.rb
@@ -1,61 +1,37 @@
 require 'spec_helper'
 
 describe Megaphone::Client::Logger do
+
   describe '#create' do
-    let(:host) { nil }
-    let(:port) { nil }
+    let(:client) { Megaphone::Client::Logger.create() }
 
-    subject { Megaphone::Client::Logger.create(host, port) }
-
-    after do
-      ENV.delete('MEGAPHONE_FLUENT_HOST')
-      ENV.delete('MEGAPHONE_FLUENT_PORT')
+    it 'creates a file logger with default configuration' do
+      expect(client).to be_an_instance_of(Megaphone::Client::FileLogger)
     end
 
-    context 'when host and port are present' do
+    context 'when custom parameters are provided' do
 
-      let(:host) { 'localhost' }
-      let(:port) { '24224' }
-
-      it 'creates a fluent logger using them' do
-        expect(subject).to be_an_instance_of(Megaphone::Client::FluentLogger)
-
-      end
-
-      context 'when megaphone fluent env variables are present' do
-        it 'creates a fluent logger using host and port (not environment variables)' do
-          ENV['MEGAPHONE_FLUENT_HOST'] = 'another-host'
-          ENV['MEGAPHONE_FLUENT_PORT'] = 'another-port'
-          expect(Megaphone::Client::FluentLogger).to receive(:new).with(host, port)
-          subject
+      context "when a custom 'host' parameter is provided" do
+        it 'creates a file logger with default configuration' do
+          lient = Megaphone::Client::Logger.create('custom host', nil)
+          expect(client).to be_an_instance_of(Megaphone::Client::FileLogger)
         end
       end
-    end
-    context 'when megaphone fluent env variables are present' do
-      it 'creates a fluent logger' do
-        ENV['MEGAPHONE_FLUENT_HOST'] = 'localhost'
-        ENV['MEGAPHONE_FLUENT_PORT'] = '24224'
-        expect(subject).to be_an_instance_of(Megaphone::Client::FluentLogger)
-      end
-    end
 
-    context 'when megaphone fluent host env variable is not present' do
-      it 'creates a file logger' do
-        ENV['MEGAPHONE_FLUENT_PORT'] = '24224'
-        expect(subject).to be_an_instance_of(Megaphone::Client::FileLogger)
+      context "when a custom 'port' parameter is provided" do
+        it 'creates a file logger with default configuration' do
+          client = Megaphone::Client::Logger.create(nil, 'custom port')
+          expect(client).to be_an_instance_of(Megaphone::Client::FileLogger)
+        end
       end
-    end
 
-    context 'when megaphone fluent port env variable is not present' do
-      it 'creates a file logger' do
-        ENV['MEGAPHONE_FLUENT_HOST'] = 'localhost'
-        expect(subject).to be_an_instance_of(Megaphone::Client::FileLogger)
-      end
-    end
+      context "when both a custom 'host' and 'port' parameters are provided" do
+        it 'creates a fluent logger using them' do
+          expect(Megaphone::Client::FluentLogger).to receive(:new).with('custom host', '424242').and_call_original
 
-    context 'when megaphone fluent env variables are not present' do
-      it 'creates a file logger' do
-        expect(subject).to be_an_instance_of(Megaphone::Client::FileLogger)
+          client = Megaphone::Client::Logger.create('custom host', '424242')
+          expect(client).to be_an_instance_of(Megaphone::Client::FluentLogger)
+        end
       end
     end
   end


### PR DESCRIPTION
**When I** contribute to the Megaphone::Client maintenance 
**I want** all the configuration to happen in the outermost class 
**So that** the concern is not spread across multiple levels 

See https://trello.com/c/KMZB4JYx/84-release-megaphoneclient-v100

:pear: @Lassi 