### PR TITLE
Adjust error messages

### DIFF
--- a/lib/megaphone/client.rb
+++ b/lib/megaphone/client.rb
@@ -18,7 +18,11 @@ module Megaphone
     def publish!(topic, subtopic, schema, partition_key, payload)
       event = Event.new(topic, subtopic, origin, schema, partition_key, payload)
       unless logger.post(topic, event.to_hash)
-        raise MegaphoneUnavailableError.new(logger.last_error.message, event)
+        if logger.last_error.message.include?("Connection reset by peer")
+          raise MegaphoneMessageDelayWarning.new(logger.last_error.message, event)
+        else
+          raise MegaphoneUnavailableError.new(logger.last_error.message, event)
+        end
       end
     end
   end

--- a/lib/megaphone/client/errors.rb
+++ b/lib/megaphone/client/errors.rb
@@ -9,7 +9,20 @@ module Megaphone
       end
 
       def to_s
-        "#{@msg} - The following event was not published: #{@event.to_s}"
+        "#{@msg} - An event could not be immediately published, but may be retried: #{@event.stream_id}"
+      end
+    end
+
+    class MegaphoneMessageDelayWarning < StandardError
+
+      def initialize(msg, event)
+        super(msg)
+        @msg = msg
+        @event = event
+      end
+
+      def to_s
+        "#{@msg} - Event delayed and will be reattempted: #{@event.stream_id}"
       end
     end
   end

--- a/lib/megaphone/client/event.rb
+++ b/lib/megaphone/client/event.rb
@@ -12,6 +12,10 @@ module Megaphone
         @payload = payload
       end
 
+      def stream_id
+        "#{@topic}.#{@subtopic}"
+      end
+
       def to_hash
         {
           schema: @schema,

--- a/spec/megaphone/client_spec.rb
+++ b/spec/megaphone/client_spec.rb
@@ -94,7 +94,7 @@ describe Megaphone::Client do
         end
 
         it 'raises an error' do
-          expect { client.publish!(topic, subtopic, schema, partition_key, payload) }.to raise_error(Megaphone::Client::MegaphoneUnavailableError, /The following event was not published/)
+          expect { client.publish!(topic, subtopic, schema, partition_key, payload) }.to raise_error(Megaphone::Client::MegaphoneUnavailableError, /An event could not be immediately published/)
         end
       end
     end


### PR DESCRIPTION
We don't want to publish entire events, containing potentially sensitive information, to Rollbar.
Also, we shouldn't report transient issues as complete failures. (eg. the very common "connection reset by peer").

This PR replaces the error messages with ones that just reference the stream topic and subtopic.