### PR TITLE
Add disclaimer to set public expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 [![Gem Version](https://badge.fury.io/rb/megaphone-client.svg)](https://badge.fury.io/rb/megaphone-client)
 ![Megaphone](https://img.shields.io/badge/Megaphone-2.0.0-blue.svg)
 
-Send events to [Megaphone](https://github.com/redbubble/Megaphone).
+Send events to [Megaphone (private)](https://github.com/redbubble/Megaphone).
+
+> **DISCLAIMER**: This is part of a currently private event broadcasting system called Megaphone. Please be aware that some links may lead to private repositories. Questions are welcome, though, and we're happy to help if you find a use for this gem, or get inspired by it!
+>
+> More of Megaphone could become public in the future, but there is currently no clear roadmap for it. -- [GB](https://github.com/gonzalo-bulnes)
 
 ## Getting Started
 


### PR DESCRIPTION
**When I** maintain a public gem that refers to private repositories 
**I want** to let people know 
**So that** they don't think the links are broken.

Thanks @stiak for the feedback.

See https://trello.com/c/0Ttm0m68/1028-help-toby-to-release-megaphone-client-ruby