### PR TITLE
Add validations to ensure that messages are valid Kinesis messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 * A [code of conduct][coc] and [contributing guidelines][contributing].
 
+### Fixed
+
+* Validation of events to ensure that Kinesis will accept them.
+
   [coc]: ./CODE_OF_CONDUCT.md
   [contributing]: ./CONTRIBUTING.md
 

--- a/README.md
+++ b/README.md
@@ -79,17 +79,23 @@ client.publish!(topic, subtopic, schema, partition_key, payload)
 
 ### Exceptions the client will raise
 
-`publish!` can raise two exceptions if the underlying Fluentd
-client library throws an error.
+#### `MegaphoneInvalidEventError`
 
-The most common is `MegaphoneMessageDelayWarning` which indicates
-a transient failure occurred, but the message will probably be resent
-later. See section on _[Internal buffering](#internal-buffering-upon-error)_ below for more details.
+Raised when the message is invalid by Kinesis's standards.
 
-The second exception is `MegaphoneUnavailableError`, which is thrown
-for all other errors. Note that these _may or may not_ also buffer
-the message for later transmission. Unfortunately the underlying
-client library does not make the distinction.
+#### `MegaphoneMessageDelayWarning`
+
+This indicates a transient failure occurred, but the message will
+probably be re-sent later. See the section on
+_[Internal buffering](#internal-buffering-upon-error)_ below for more
+details.
+
+#### `MegaphoneUnavailableError`
+
+This is raised for all other errors. Note that
+these _may or may not_ also buffer the message for later
+transmission. Unfortunately the underlying client library does not
+make the distinction.
 
 ### Internal buffering upon error
 

--- a/lib/megaphone/client.rb
+++ b/lib/megaphone/client.rb
@@ -22,6 +22,7 @@ module Megaphone
 
     def publish!(topic, subtopic, schema, partition_key, payload)
       event = Event.new(topic, subtopic, origin, schema, partition_key, payload)
+      raise MegaphoneInvalidEventError.new(event.errors.join(', ')) unless event.valid?
       unless logger.post(topic, event.to_hash)
         if transient_error?(logger.last_error)
           raise MegaphoneMessageDelayWarning.new(logger.last_error.message, event)

--- a/lib/megaphone/client.rb
+++ b/lib/megaphone/client.rb
@@ -25,9 +25,9 @@ module Megaphone
       raise MegaphoneInvalidEventError.new(event.errors.join(', ')) unless event.valid?
       unless logger.post(topic, event.to_hash)
         if transient_error?(logger.last_error)
-          raise MegaphoneMessageDelayWarning.new(logger.last_error.message, event)
+          raise MegaphoneMessageDelayWarning.new(logger.last_error.message, event.stream_id)
         else
-          raise MegaphoneUnavailableError.new(logger.last_error.message, event)
+          raise MegaphoneUnavailableError.new(logger.last_error.message, event.stream_id)
         end
       end
     end

--- a/lib/megaphone/client/errors.rb
+++ b/lib/megaphone/client/errors.rb
@@ -25,5 +25,17 @@ module Megaphone
         "#{@msg} - Event delayed and will be reattempted: #{@event.stream_id}"
       end
     end
+
+    class MegaphoneInvalidEventError < StandardError
+
+      def initialize(msg)
+        super(msg)
+        @msg = msg
+      end
+
+      def to_s
+        "Invalid Megaphone event was not sent: #{@msg}"
+      end
+    end
   end
 end

--- a/lib/megaphone/client/errors.rb
+++ b/lib/megaphone/client/errors.rb
@@ -2,39 +2,23 @@ module Megaphone
   class Client
     class MegaphoneUnavailableError < StandardError
 
-      def initialize(msg, event)
-        super(msg)
-        @msg = msg
-        @event = event
-      end
-
-      def to_s
-        "#{@msg} - An event could not be immediately published, but may be retried: #{@event.stream_id}"
+      def initialize(msg, stream_id)
+        super("#{msg} - An event could not be immediately published, but may be retried: #{stream_id}")
       end
     end
 
     class MegaphoneMessageDelayWarning < StandardError
 
-      def initialize(msg, event)
-        super(msg)
-        @msg = msg
-        @event = event
-      end
-
-      def to_s
-        "#{@msg} - Event delayed and will be reattempted: #{@event.stream_id}"
+      def initialize(msg, stream_id)
+        super("#{msg} - Event delayed and will be reattempted: #{stream_id}")
       end
     end
 
     class MegaphoneInvalidEventError < StandardError
 
       def initialize(msg)
-        super(msg)
+        super("Invalid Megaphone event was not sent: #{msg}")
         @msg = msg
-      end
-
-      def to_s
-        "Invalid Megaphone event was not sent: #{@msg}"
       end
     end
   end

--- a/lib/megaphone/client/event.rb
+++ b/lib/megaphone/client/event.rb
@@ -30,6 +30,26 @@ module Megaphone
       def to_s
         JSON.dump(to_hash)
       end
+
+      def errors
+        errors = []
+        errors << 'partition_key must not be empty' if missing?(@partition_key)
+        errors << 'topic must not be empty' if missing?(@topic)
+        errors << 'subtopic must not be empty' if missing?(@subtopic)
+        errors << 'payload must not be empty' if missing?(@payload)
+        errors << 'origin must not be empty' if missing?(@origin)
+        errors
+      end
+
+      def valid?
+        errors.empty?
+      end
+
+      private
+
+      def missing?(field)
+        not (field && field.to_s.length > 0)
+      end
     end
   end
 end

--- a/spec/megaphone/client/event_spec.rb
+++ b/spec/megaphone/client/event_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe Megaphone::Client::Event do
+  let(:topic) { 'user-events' }
+  let(:subtopic) { 'user-viewed-work' }
+  let(:origin) { 'redbubble' }
+  let(:schema) { 'https://schema.example.com/path.json' }
+  let(:partition_key) { 'abc123' }
+  let(:payload) { '{message: "hello, world"}' }
+  let(:event) { Megaphone::Client::Event.new(topic, subtopic, origin, schema, partition_key, payload) }
+
+  describe '#errors' do
+    let(:subject) { event.errors }
+
+    it { is_expected.to eq([]) }
+
+    context 'when the payload is missing' do
+      let(:payload) { nil }
+      it { is_expected.to include('payload must not be empty') }
+    end
+    context 'when the topic is missing' do
+      let(:topic) { nil }
+      it { is_expected.to include('topic must not be empty') }
+    end
+    context 'when the subtopic is missing' do
+      let(:subtopic) { nil }
+      it { is_expected.to include('subtopic must not be empty') }
+    end
+    context 'when the partition key is missing' do
+      let(:partition_key) { nil }
+      it { is_expected.to include('partition_key must not be empty') }
+    end
+    context 'when the origin is missing' do
+      let(:origin) { nil }
+      it { is_expected.to include('origin must not be empty') }
+    end
+    context 'when more than one field is missing' do
+      let(:origin) { nil }
+      let(:payload) { nil }
+      it { is_expected.to include('origin must not be empty') }
+      it { is_expected.to include('payload must not be empty') }
+    end
+  end
+
+  describe '#valid?' do
+    let(:subject) { event.valid? }
+
+    it { is_expected.to be true }
+
+    context 'when the topic is missing' do
+      let(:topic) { nil }
+      it { is_expected.to be false }
+    end
+
+    context 'when the subtopic is missing' do
+      let(:subtopic) { nil }
+      it { is_expected.to be false }
+    end
+
+    context 'when the origin is missing' do
+      let(:origin) { nil }
+      it { is_expected.to be false }
+    end
+
+    context 'when the payload is missing' do
+      let(:payload) { nil }
+      it { is_expected.to be false }
+    end
+
+    context 'when the partition_key is missing' do
+      let(:partition_key) { nil }
+      it { is_expected.to be false }
+    end
+
+    context 'when more than one field is missing' do
+      let(:origin) { nil }
+      let(:payload) { nil }
+      it { is_expected.to be false }
+    end
+  end
+end


### PR DESCRIPTION
**When I** retry sending messages to Kinesis until they succeeed 
**I want** my client to validate that all that's sent are valid Kinesis messages 
**So that** I don't get stuck in a retry loop

Validations:

- [ ] ~everything in the Megaphone message is valid Unicode~
- [x] it has a non-zero-length partition key
- [x] and a non-empty payload

I didn't forget to:

* [x] update the `README`
* [x] add [specs](../spec) for the changes I made
* [x] update the `CHANGELOG`, describing the relevant changes as [**Unreleased**](https://keepachangelog.com)
* [x] evaluate the impact of this change to the Megaphone client API (other clients do implement the API)
* [x] get in touch with other Megaphone clients maintainers to coordinate relevant updates

See https://trello.com/c/5v8apwIU/1070-add-basic-validation-to-megaphoneclient-ruby 

🍐 @chrismears 