### PR TITLE
Add contributing guidelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
   - 2.2.5
-  - ruby-head
+  - 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and
 this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* A [code of conduct][coc] and [contributing guidelines][contributing].
+
+  [coc]: ./CODE_OF_CONDUCT.md
+  [contributing]: ./CONTRIBUTING.md
+
 ## [1.1.0] - 2018-01-30
 
 ### Added

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at gonzalo.bulnes@redbubble.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing
+
+We love pull requests from everyone, and we welcome them specially when they are your first ones!
+By participating in this project, you agree to abide its [code of conduct][coc].
+
+[coc]: ./CODE_OF_CONDUCT.md
+
+Fork, then clone the repo:
+
+    git clone git@github.com:your-username/megaphone-client-ruby.git
+
+Set up your machine:
+
+    # install Ruby if necessary
+    # then install the project development dependencies:
+    bundle install
+
+Make sure the tests pass:
+
+    # Run the entire test suite
+    rake
+
+    # Otherwise...
+    rake spec
+
+Add tests for your change. Make sure that they fail. Make your change so that the tests pass:
+
+    rake
+
+Push to your fork and [submit a pull request][pr].
+
+[pr]: https://github.com/redbubble/megaphone-client-ruby/compare/
+
+At this point you're waiting on us. We'll make sure to at least comment quickly and guide you through any required changes.
+
+Some things that will increase the chance that your pull request is accepted:
+
+* Write tests.
+* Ask for help if you need it!
+* Write a [thoughtful commit message][commit].
+
+[commit]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html

--- a/README.md
+++ b/README.md
@@ -167,17 +167,12 @@ Unfortunately there is no means to do this with the underlying Ruby client
 for Fluentd. It would require patches to the upstream code to expose a flush
 method.
 
-## Development
+## Contributing
 
-### Testing
+Want to contribute? Amazing! Our [contributing guidelines][contributing], and [code of conduct][coc] are here to get you started and make you feel welcome!
 
-```bash
-# Run the entire test suite
-rake
-
-# Otherwise...
-rake spec
-```
+[coc]: ./CODE_OF_CONDUCT.md
+[contributing]: ./CONTRIBUTING.md
 
 ## Credits
 


### PR DESCRIPTION
**When I** contribute to Megaphone::Client 
**I want to** find contributing guidelines and a code of conduct in the project 
**So that** I know that its maintainers care about contributions 
**And** I can get started or ask for help if needed 

I didn't forget to:

* [x] update the `README`
* [ ] ~~add [specs](../spec) for the changes I made~~
* [x] update the `CHANGELOG`, describing the relevant changes as [**Unreleased**](https://keepachangelog.com)
* [x] evaluate the impact of this change to the Megaphone client API (other clients do implement the API)
* [x] get in touch with other Megaphone clients maintainers to coordinate relevant updates

See https://trello.com/c/5v8apwIU/1070-add-basic-validation-to-megaphoneclient-ruby
