### PR TITLE
Use fluent's default port (24224) if it's not given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and
 this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+* If no port specified (via parameter or environment) then the default
+  Fluentd port will be used.
+
 ## [1.1.1] - 2018-02-09
 
 ### Added

--- a/lib/megaphone/client.rb
+++ b/lib/megaphone/client.rb
@@ -8,6 +8,8 @@ module Megaphone
     attr_reader :logger, :origin
     private :logger, :origin
 
+    FLUENT_DEFAULT_PORT = 24224
+
     # Main entry point for apps using this library.
     # Will default to environment for host and port settings, if not passed.
     # Note that a missing callback_handler will result in a default handler
@@ -15,7 +17,7 @@ module Megaphone
     def initialize(config)
       @origin = config.fetch(:origin)
       host = config.fetch(:host, ENV['MEGAPHONE_FLUENT_HOST'])
-      port = config.fetch(:port, ENV['MEGAPHONE_FLUENT_PORT'])
+      port = config.fetch(:port, ENV['MEGAPHONE_FLUENT_PORT'] || FLUENT_DEFAULT_PORT)
       overflow_handler = config.fetch(:overflow_handler, nil)
       @logger = Megaphone::Client::Logger.create(host, port, overflow_handler)
     end

--- a/spec/megaphone/client_spec.rb
+++ b/spec/megaphone/client_spec.rb
@@ -10,7 +10,7 @@ describe Megaphone::Client do
     let(:config) {{ origin: 'my-awesome-service' }}
 
     it 'creates a logger', focus: true do
-      expect(Megaphone::Client::Logger).to receive(:create).with(nil, nil, nil)
+      expect(Megaphone::Client::Logger).to receive(:create).with(nil, Megaphone::Client::FLUENT_DEFAULT_PORT, nil)
       described_class.new(config)
     end
 


### PR DESCRIPTION
**When I** don't explicitly pass a port to the library, I expect it to assume a sensible default.
**So that** I don't silently, without error, stop sending messages to fluentd.

Without this PR, the client will actually silently fail to pass messages to fluentd, unless a port is passed explicitly via environment or parameter. No error is reported.

The usual behaviour of client libraries is to assume a default port, unless overridden.
