### PR TITLE
Add optional 'origin' argument to .publish!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and
 this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* Add options hash argument to `.publish!` with support for overriding the `origin` attribute
+
 ## [1.1.2] - 2018-03-05
 
 ### Changed
@@ -82,6 +88,8 @@ this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 * Initial implementation of the `Megaphone::Client.publish!` method
 
+  [Unreleased]: https://github.com/redbubble/megaphone-client-ruby/compare/v1.1.2...master
+  [1.1.2]: https://github.com/redbubble/megaphone-client-ruby/compare/v1.1.1...v1.1.2
   [1.1.1]: https://github.com/redbubble/megaphone-client-ruby/compare/v1.1.0...v1.1.1
   [1.1.0]: https://github.com/redbubble/megaphone-client-ruby/compare/v1.0.1...v1.1.0
   [1.0.1]: https://github.com/redbubble/megaphone-client-ruby/compare/v1.0.0...v1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 ### Added
 
-* Add options hash argument to `.publish!` with support for overriding the `origin` attribute
+* Add options hash argument to `.publish!` with support for overriding the `origin` attribute.
+* Add validation of origin in `.publish!` - `MegaphoneMissingOriginError` will be raised if missing.
 
 ## [1.1.2] - 2018-03-05
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ payload = { url: 'https://www.redbubble.com/people/wytrab8/works/26039653-toadal
 # Publish your event
 client.publish!(topic, subtopic, schema, partition_key, payload)
 
+# You can optionally provide an options hash, that can be used to override the origin attribute:
+client.publish!(topic, subtopic, schema, partition_key, payload, origin: 'a-different-service')
+
 # Note: the client will close the connection to Fluentd on exit, if you need to do it before that (unlikely), you can use Megaphone::Client#close method.
 
 # See below for error handling instructions and examples.

--- a/lib/megaphone/client.rb
+++ b/lib/megaphone/client.rb
@@ -5,8 +5,8 @@ require 'megaphone/client/version'
 
 module Megaphone
   class Client
-    attr_reader :logger, :origin
-    private :logger, :origin
+    attr_reader :logger, :default_origin
+    private :logger, :default_origin
 
     FLUENT_DEFAULT_PORT = 24224
 
@@ -15,14 +15,15 @@ module Megaphone
     # Note that a missing callback_handler will result in a default handler
     # being assigned if the FluentLogger is used.
     def initialize(config)
-      @origin = config.fetch(:origin)
+      @default_origin = config.fetch(:origin)
       host = config.fetch(:host, ENV['MEGAPHONE_FLUENT_HOST'])
       port = config.fetch(:port, ENV['MEGAPHONE_FLUENT_PORT'] || FLUENT_DEFAULT_PORT)
       overflow_handler = config.fetch(:overflow_handler, nil)
       @logger = Megaphone::Client::Logger.create(host, port, overflow_handler)
     end
 
-    def publish!(topic, subtopic, schema, partition_key, payload)
+    def publish!(topic, subtopic, schema, partition_key, payload, options = {})
+      origin = options[:origin] || default_origin
       event = Event.new(topic, subtopic, origin, schema, partition_key, payload)
       raise MegaphoneInvalidEventError.new(event.errors.join(', ')) unless event.valid?
       unless logger.post(topic, event.to_hash)

--- a/lib/megaphone/client.rb
+++ b/lib/megaphone/client.rb
@@ -24,6 +24,7 @@ module Megaphone
 
     def publish!(topic, subtopic, schema, partition_key, payload, options = {})
       origin = options[:origin] || default_origin
+      raise MegaphoneMissingOriginError if origin.nil? || origin.empty?
       event = Event.new(topic, subtopic, origin, schema, partition_key, payload)
       raise MegaphoneInvalidEventError.new(event.errors.join(', ')) unless event.valid?
       unless logger.post(topic, event.to_hash)

--- a/lib/megaphone/client/errors.rb
+++ b/lib/megaphone/client/errors.rb
@@ -18,7 +18,13 @@ module Megaphone
 
       def initialize(msg)
         super("Invalid Megaphone event was not sent: #{msg}")
-        @msg = msg
+      end
+    end
+
+    class MegaphoneMissingOriginError < StandardError
+
+      def initialize
+        super("Megaphone messages must have an origin. Ensure you provide an origin option, or have initialized the client with a default.")
       end
     end
   end

--- a/spec/megaphone/client_spec.rb
+++ b/spec/megaphone/client_spec.rb
@@ -76,13 +76,20 @@ describe Megaphone::Client do
         client.publish!(topic, subtopic, schema, partition_key, payload)
       end
 
-      context 'when sending event from My Awesome Service' do
+      context 'when client is initialized with origin "My Awesome Service"' do
 
         let(:config) { { origin: 'my-awesome-service' } }
 
         it 'sends the event to fluentd with the origin as my awesome service' do
           expect(logger).to receive(:post).with(topic, hash_including(origin: 'my-awesome-service'))
           client.publish!(topic, subtopic, schema, partition_key, payload)
+        end
+      end
+
+      context 'when origin is provided to .publish! in the options hash' do
+        it 'overrides the origin' do
+          expect(logger).to receive(:post).with(topic, hash_including(origin: 'myOrigin'))
+          client.publish!(topic, subtopic, schema, partition_key, payload, origin: 'myOrigin')
         end
       end
 

--- a/spec/megaphone/client_spec.rb
+++ b/spec/megaphone/client_spec.rb
@@ -87,9 +87,22 @@ describe Megaphone::Client do
       end
 
       context 'when origin is provided to .publish! in the options hash' do
+
         it 'overrides the origin' do
           expect(logger).to receive(:post).with(topic, hash_including(origin: 'myOrigin'))
           client.publish!(topic, subtopic, schema, partition_key, payload, origin: 'myOrigin')
+        end
+      end
+
+      context 'when origin is missing' do
+        let(:config) { { origin: nil } }
+
+        it 'raises an error' do
+          expect { client.publish!(topic, subtopic, schema, partition_key, payload, origin: '') }.to raise_error(Megaphone::Client::MegaphoneMissingOriginError)
+        end
+
+        it 'raises an error' do
+          expect { client.publish!(topic, subtopic, schema, partition_key, payload, origin: nil) }.to raise_error(Megaphone::Client::MegaphoneMissingOriginError)
         end
       end
 


### PR DESCRIPTION
[Trello 📁](https://trello.com/c/f0CASMo1)

**When I** use the `megaphone-client`
**I want to** be able to publish events from different origins
**So that** consumers can act accordingly.

:pear: @gonzalo-bulnes 

I didn't forget to:

* [x] update the `README`
* [x] add [specs](../spec) for the changes I made
* [x] update the `CHANGELOG`, describing the relevant changes as [**Unreleased**](https://keepachangelog.com)
* [x] evaluate the impact of this change to the Megaphone client API (other clients do implement the API)
* [x] get in touch with other Megaphone clients maintainers to coordinate relevant updates