### PR TITLE
Fix missing Gemfile.lock update after last release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    megaphone-client (1.1.1)
+    megaphone-client (1.1.2)
       fluent-logger (~> 0.7.0)
 
 GEM
@@ -10,7 +10,7 @@ GEM
     diff-lcs (1.3)
     fluent-logger (0.7.2)
       msgpack (>= 1.0.0, < 2)
-    msgpack (1.2.2)
+    msgpack (1.2.4)
     rake (10.5.0)
     rspec (3.6.0)
       rspec-core (~> 3.6.0)
@@ -35,4 +35,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.15.3
+   1.16.1


### PR DESCRIPTION
This PR is a follow up on 11dd8e83655e3260f3e01869a496359de883000b

Outdated `Gemfile.lock` was causing CI failures. This is the result of running `bundle install` on `master`, with latest `bundler` installed. 

* [x] update the `README`
* [x] add [specs](../spec) for the changes I made
* [x] update the `CHANGELOG`, describing the relevant changes as [**Unreleased**](https://keepachangelog.com)
* [x] evaluate the impact of this change to the Megaphone client API (other clients do implement the API)
* [x] get in touch with other Megaphone clients maintainers to coordinate relevant updates