### PR TITLE
Add transactionId support & simplify publish! signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and
 this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+* Signature of `Client#publish!`: now take two hash arguments: `payload` & `metadata`. Previously __required__ arguments (e.g., `partition_key`) are now __required__ attributes of the `metadata` hash.
+* New __required__ event attribute `transactionId`.
+
 ## [1.1.2] - 2018-03-05
 
 ### Changed
@@ -82,6 +89,8 @@ this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 
 * Initial implementation of the `Megaphone::Client.publish!` method
 
+  [Unreleased]: https://github.com/redbubble/megaphone-client-ruby/compare/v1.1.2...master
+  [1.1.2]: https://github.com/redbubble/megaphone-client-ruby/compare/v1.1.1...v1.1.2
   [1.1.1]: https://github.com/redbubble/megaphone-client-ruby/compare/v1.1.0...v1.1.1
   [1.1.0]: https://github.com/redbubble/megaphone-client-ruby/compare/v1.0.1...v1.1.0
   [1.0.1]: https://github.com/redbubble/megaphone-client-ruby/compare/v1.0.0...v1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html
 ### Changed
 
 * Signature of `Client#publish!`: now take two hash arguments: `payload` & `metadata`. Previously __required__ arguments (e.g., `partition_key`) are now __required__ attributes of the `metadata` hash.
-* New __required__ event attribute `transactionId`.
+
+### Added
+
+* Support for new event metadata attribute `transactionId`. This is a 'required' attribute, however one will be automatically generated if it is not provided.
 
 ## [1.1.2] - 2018-03-05
 

--- a/README.md
+++ b/README.md
@@ -60,15 +60,21 @@ client = Megaphone::Client.new({
   port: '24224'
 })
 
-# Create an event
-topic = 'work-updates'
-subtopic = 'work-metadata-updated'
-schema = 'https://github.com/redbubble/megaphone-event-type-registry/blob/master/streams/work-updates-schema-1.0.0.json'
-partition_key = '1357924680' # the Work ID in this case
-payload = { url: 'https://www.redbubble.com/people/wytrab8/works/26039653-toadally-rad' }
+# Prepare an event payload and associated metadata
+payload = {
+  url: 'https://www.redbubble.com/people/wytrab8/works/26039653-toadally-rad'
+}
+
+metadata = {
+  topic: 'work-updates',
+  subtopic: 'work-metadata-updated',
+  schema: 'https://github.com/redbubble/megaphone-event-type-registry/blob/master/streams/work-updates-schema-1.0.0.json',
+  partition_key: '1357924680', # the Work ID in this case
+  transaction_id: 'transaction-id', # a unique identifier for this action
+}
 
 # Publish your event
-client.publish!(topic, subtopic, schema, partition_key, payload)
+client.publish!(payload, metadata)
 
 # Note: the client will close the connection to Fluentd on exit, if you need to do it before that (unlikely), you can use Megaphone::Client#close method.
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ client.publish!(payload, metadata)
 
 # Note: the client will close the connection to Fluentd on exit, if you need to do it before that (unlikely), you can use Megaphone::Client#close method.
 
+# If you do not provide a transaction_id metadata attribute, a random (v4) UUID will be generated and used automatically.
+
 # See below for error handling instructions and examples.
 ```
 

--- a/lib/megaphone/client.rb
+++ b/lib/megaphone/client.rb
@@ -8,7 +8,7 @@ module Megaphone
     attr_reader :logger, :origin
     private :logger, :origin
 
-    FLUENT_DEFAULT_PORT = 24224
+    FLUENT_DEFAULT_PORT = '24224'
 
     # Main entry point for apps using this library.
     # Will default to environment for host and port settings, if not passed.

--- a/lib/megaphone/client/event.rb
+++ b/lib/megaphone/client/event.rb
@@ -3,7 +3,7 @@ require 'json'
 module Megaphone
   class Client
     class Event
-      REQUIRED_ATTRIBUTES = [:partition_key, :topic, :subtopic, :payload, :origin]
+      REQUIRED_ATTRIBUTES = [:partition_key, :topic, :subtopic, :payload, :origin, :transaction_id]
 
       def initialize(payload, metadata = {})
         @topic = metadata[:topic]
@@ -11,6 +11,7 @@ module Megaphone
         @origin = metadata[:origin]
         @schema = metadata[:schema]
         @partition_key = metadata[:partition_key]
+        @transaction_id = metadata[:transaction_id]
         @payload = payload
       end
 
@@ -25,6 +26,7 @@ module Megaphone
           topic: @topic,
           subtopic: @subtopic,
           partitionKey: @partition_key,
+          transactionId: @transaction_id,
           data: @payload,
         }
       end

--- a/lib/megaphone/client/event.rb
+++ b/lib/megaphone/client/event.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'securerandom'
 
 module Megaphone
   class Client
@@ -11,7 +12,7 @@ module Megaphone
         @origin = metadata[:origin]
         @schema = metadata[:schema]
         @partition_key = metadata[:partition_key]
-        @transaction_id = metadata[:transaction_id]
+        @transaction_id = metadata[:transaction_id] || generate_transaction_id
         @payload = payload
       end
 
@@ -57,6 +58,10 @@ module Megaphone
 
       def missing?(field)
         not (field && field.to_s.length > 0)
+      end
+
+      def generate_transaction_id
+        SecureRandom.uuid
       end
     end
   end

--- a/spec/megaphone/client/event_spec.rb
+++ b/spec/megaphone/client/event_spec.rb
@@ -7,7 +7,16 @@ describe Megaphone::Client::Event do
   let(:schema) { 'https://schema.example.com/path.json' }
   let(:partition_key) { 'abc123' }
   let(:payload) { '{message: "hello, world"}' }
-  let(:event) { Megaphone::Client::Event.new(topic, subtopic, origin, schema, partition_key, payload) }
+  let(:metadata) do
+    {
+      topic: topic,
+      subtopic: subtopic,
+      origin: origin,
+      schema: schema,
+      partition_key: partition_key,
+    }
+  end
+  let(:event) { Megaphone::Client::Event.new(payload, metadata) }
 
   describe '#errors' do
     let(:subject) { event.errors }
@@ -18,22 +27,27 @@ describe Megaphone::Client::Event do
       let(:payload) { nil }
       it { is_expected.to include('payload must not be empty') }
     end
+
     context 'when the topic is missing' do
       let(:topic) { nil }
       it { is_expected.to include('topic must not be empty') }
     end
+
     context 'when the subtopic is missing' do
       let(:subtopic) { nil }
       it { is_expected.to include('subtopic must not be empty') }
     end
+
     context 'when the partition key is missing' do
       let(:partition_key) { nil }
       it { is_expected.to include('partition_key must not be empty') }
     end
+
     context 'when the origin is missing' do
       let(:origin) { nil }
       it { is_expected.to include('origin must not be empty') }
     end
+
     context 'when more than one field is missing' do
       let(:origin) { nil }
       let(:payload) { nil }

--- a/spec/megaphone/client/event_spec.rb
+++ b/spec/megaphone/client/event_spec.rb
@@ -92,4 +92,22 @@ describe Megaphone::Client::Event do
       it { is_expected.to be false }
     end
   end
+
+  describe '#validate!' do
+    let(:subject) { event }
+
+    context 'when a required attribute is missing' do
+      let(:origin) { nil }
+
+      it 'raises an error if the event is not valid' do
+        expect { subject.validate! }.to raise_error(Megaphone::Client::MegaphoneInvalidEventError, /origin must not be empty/)
+      end
+    end
+
+    context 'when event is valid' do
+      it 'does not raise' do
+        expect { subject.validate! }.not_to raise_error
+      end
+    end
+  end
 end

--- a/spec/megaphone/client/event_spec.rb
+++ b/spec/megaphone/client/event_spec.rb
@@ -20,6 +20,24 @@ describe Megaphone::Client::Event do
   end
   let(:event) { Megaphone::Client::Event.new(payload, metadata) }
 
+  describe '#initialize' do
+    context 'when a transaction_id is not provided' do
+      let(:transaction_id) { nil }
+
+      it 'generates a new transaction_id' do
+        expect(event.to_hash[:transactionId]).not_to be_empty
+      end
+    end
+
+    context 'when given a transaction_id' do
+      let(:transaction_id) { 'my-transaction_id' }
+
+      it 'uses the provided transaction_id' do
+        expect(event.to_hash[:transactionId]).to eq('my-transaction_id')
+      end
+    end
+  end
+
   describe '#errors' do
     let(:subject) { event.errors }
 
@@ -48,11 +66,6 @@ describe Megaphone::Client::Event do
     context 'when the origin is missing' do
       let(:origin) { nil }
       it { is_expected.to include('origin must not be empty') }
-    end
-
-    context 'when the transaction id is missing' do
-      let(:transaction_id) { nil }
-      it { is_expected.to include('transaction_id must not be empty') }
     end
 
     context 'when more than one field is missing' do

--- a/spec/megaphone/client/event_spec.rb
+++ b/spec/megaphone/client/event_spec.rb
@@ -6,6 +6,7 @@ describe Megaphone::Client::Event do
   let(:origin) { 'redbubble' }
   let(:schema) { 'https://schema.example.com/path.json' }
   let(:partition_key) { 'abc123' }
+  let(:transaction_id) { 'transaction-id' }
   let(:payload) { '{message: "hello, world"}' }
   let(:metadata) do
     {
@@ -14,6 +15,7 @@ describe Megaphone::Client::Event do
       origin: origin,
       schema: schema,
       partition_key: partition_key,
+      transaction_id: transaction_id,
     }
   end
   let(:event) { Megaphone::Client::Event.new(payload, metadata) }
@@ -46,6 +48,11 @@ describe Megaphone::Client::Event do
     context 'when the origin is missing' do
       let(:origin) { nil }
       it { is_expected.to include('origin must not be empty') }
+    end
+
+    context 'when the transaction id is missing' do
+      let(:transaction_id) { nil }
+      it { is_expected.to include('transaction_id must not be empty') }
     end
 
     context 'when more than one field is missing' do

--- a/spec/megaphone/client_spec.rb
+++ b/spec/megaphone/client_spec.rb
@@ -56,6 +56,14 @@ describe Megaphone::Client do
     let(:schema) { 'http://github.com/redbuble/megaphone-event-type-registry/streams/work-updates-1.0.0.json' }
     let(:payload) { { url: 'http://example.rb.com/works/123456' } }
     let(:partition_key) { 42 }
+    let(:metadata) do
+      {
+        topic: topic,
+        subtopic: subtopic,
+        schema: schema,
+        partition_key: partition_key,
+      }
+    end
 
     before do
       allow(Megaphone::Client::Logger).to receive(:create).and_return(logger)
@@ -73,7 +81,7 @@ describe Megaphone::Client do
           partitionKey: partition_key,
           data: payload
         })
-        client.publish!(topic, subtopic, schema, partition_key, payload)
+        client.publish!(payload, metadata)
       end
 
       context 'when sending event from My Awesome Service' do
@@ -82,7 +90,7 @@ describe Megaphone::Client do
 
         it 'sends the event to fluentd with the origin as my awesome service' do
           expect(logger).to receive(:post).with(topic, hash_including(origin: 'my-awesome-service'))
-          client.publish!(topic, subtopic, schema, partition_key, payload)
+          client.publish!(payload, metadata)
         end
       end
 
@@ -94,7 +102,7 @@ describe Megaphone::Client do
         end
 
         it 'raises an error' do
-          expect { client.publish!(topic, subtopic, schema, partition_key, payload) }.to raise_error(Megaphone::Client::MegaphoneUnavailableError, /An event could not be immediately published/)
+          expect { client.publish!(payload, metadata) }.to raise_error(Megaphone::Client::MegaphoneUnavailableError, /An event could not be immediately published/)
         end
       end
     end
@@ -112,7 +120,7 @@ describe Megaphone::Client do
         expect(File).to receive(:open).with(expected_filename, expected_file_permission).and_yield(file)
         expect(file).to receive(:puts).with(expected_file_content)
 
-        client.publish!(topic, subtopic, schema, partition_key, payload)
+        client.publish!(payload, metadata)
       end
     end
   end
@@ -123,6 +131,14 @@ describe Megaphone::Client do
     let(:schema) { 'http://github.com/redbuble/megaphone-event-type-registry/streams/work-updates-1.0.0.json' }
     let(:payload) { { url: 'http://example.rb.com/works/123456' } }
     let(:partition_key) { 42 }
+    let(:metadata) do
+      {
+        topic: topic,
+        subtopic: subtopic,
+        schema: schema,
+        partition_key: partition_key,
+      }
+    end
 
     context 'when overflow_handler was configured' do
       handler_called = 0
@@ -140,7 +156,7 @@ describe Megaphone::Client do
       it 'calls the overflow handler on close if messages did not send' do
         client = described_class.new(my_config)
         begin
-          client.publish!(topic, subtopic, schema, partition_key, payload)
+          client.publish!(payload, metadata)
         rescue Megaphone::Client::MegaphoneUnavailableError => e
           puts("ignoring MegaphoneUnavailableError")
         end

--- a/spec/megaphone/client_spec.rb
+++ b/spec/megaphone/client_spec.rb
@@ -56,12 +56,14 @@ describe Megaphone::Client do
     let(:schema) { 'http://github.com/redbuble/megaphone-event-type-registry/streams/work-updates-1.0.0.json' }
     let(:payload) { { url: 'http://example.rb.com/works/123456' } }
     let(:partition_key) { 42 }
+    let(:transaction_id) { 'transaction-id' }
     let(:metadata) do
       {
         topic: topic,
         subtopic: subtopic,
         schema: schema,
         partition_key: partition_key,
+        transaction_id: transaction_id,
       }
     end
 
@@ -79,6 +81,7 @@ describe Megaphone::Client do
           subtopic: subtopic,
           origin: 'some-service',
           partitionKey: partition_key,
+          transactionId: transaction_id,
           data: payload
         })
         client.publish!(payload, metadata)
@@ -112,7 +115,7 @@ describe Megaphone::Client do
       let(:expected_filename) { "work-updates.stream" }
       let(:expected_file_permission) { "a" }
       let(:expected_file_content) do
-        "{\"schema\":\"#{schema}\",\"origin\":\"some-service\",\"topic\":\"work-updates\",\"subtopic\":\"work-metadata-updated\",\"partitionKey\":42,\"data\":{\"url\":\"http://example.rb.com/works/123456\"}}"
+        "{\"schema\":\"#{schema}\",\"origin\":\"some-service\",\"topic\":\"work-updates\",\"subtopic\":\"work-metadata-updated\",\"partitionKey\":42,\"transactionId\":\"transaction-id\",\"data\":{\"url\":\"http://example.rb.com/works/123456\"}}"
       end
 
       it 'sends the event to a file' do
@@ -131,12 +134,14 @@ describe Megaphone::Client do
     let(:schema) { 'http://github.com/redbuble/megaphone-event-type-registry/streams/work-updates-1.0.0.json' }
     let(:payload) { { url: 'http://example.rb.com/works/123456' } }
     let(:partition_key) { 42 }
+    let(:transaction_id) { 'transaction-id' }
     let(:metadata) do
       {
         topic: topic,
         subtopic: subtopic,
         schema: schema,
         partition_key: partition_key,
+        transaction_id: transaction_id,
       }
     end
 


### PR DESCRIPTION
| [TRELLOCARD](https://trello.com/c/eK8oHJ6o) |
| -------------- |

### Overview

We are adding a new Megaphone metadata attribute `transactionId` to enable us to trace individual actions across multiple events/systems.

This PR does two things:

* alters the method signature of `Client#publish!` to take all metadata in a single hash argument: 

```
client.publish!(payload, metadata)
```

* adds a new __required__ metadata attribute: `transactionId` 

I have also done some light refactoring to make `Event` a bit more extensible and added some tests. 

I didn't forget to:

* [ ] update the `README`
* [ ] add [specs](../spec) for the changes I made
* [ ] update the `CHANGELOG`, describing the relevant changes as [**Unreleased**](https://keepachangelog.com)
* [ ] evaluate the impact of this change to the Megaphone client API (other clients do implement the API)
* [ ] get in touch with other Megaphone clients maintainers to coordinate relevant updates